### PR TITLE
clarified diff of two servers

### DIFF
--- a/introduction/getting-started-guide.md
+++ b/introduction/getting-started-guide.md
@@ -65,6 +65,7 @@ CommandBox> cfconfig transfer from=oneServer to=anotherServer
 ## Diff all the settings between two servers
 
 ```text
+CommandBox> cfconfig diff from=oneServer to=anotherServer
 CommandBox> cfconfig diff to=anotherServerName
 CommandBox> cfconfig diff to=anotherServerName --fromOnly
 CommandBox> cfconfig diff to=anotherServerName --toOnly


### PR DESCRIPTION
Added clarification that diff can be done between two servers (from "from" and "to"). 

The current listed examples presumed only to compare a current commandbox server "to" another.

And while the others use "anotherservername", I changed the new line to use "oneserver" and "another", like is used on the "transfer" example right above it (and since the from and to values could be paths to the server settings home, rather than just the name of another commandbox server).