### PR TITLE
update to add lucee 6/7 example

### DIFF
--- a/using-the-cli/usage.md
+++ b/using-the-cli/usage.md
@@ -8,6 +8,25 @@ CFConfig must determine the server(s) on which to operate, which will either be 
 2. You provide a file path to the server home by using the `to` and/or `from` parameters.
 3. You provide the name of a previously-started CommandBox server, using `to` and/or `from` parameters (see [CommandBox Managing Servers](https://commandbox.ortusbooks.com/embedded-server/manage-servers)).
 
+### Lucee 6/7
+
+The folder containing the `/context/.CFConfig.json` file. An example would be:
+
+```bash
+C:/lucee/tomcat/lucee-server/ 
+cfconfig export from=C:/lucee/tomcat/lucee-server/ fromFormat=luceeServer to=myconfig.json
+```
+
+### Lucee 4/5 Server Context
+
+The folder containing the `/context/lucee-server.xml` file. An example would be:
+
+```bash
+C:/lucee/tomcat/lucee-server/
+
+cfconfig export from=C:/lucee/tomcat/lucee-server/ to=myconfig.json
+```
+
 ### Lucee 4/5 Web Context
 
 The folder containing the `lucee-web.xml.cfm` file. An example would be:
@@ -16,16 +35,6 @@ The folder containing the `lucee-web.xml.cfm` file. An example would be:
 <webroot>C:/myapp/WEB-INF/lucee/
 
 cfconfig export from=C:/myapp/WEB-INF/lucee/ to=myconfig.json
-```
-
-### Lucee 4/5 Server Context
-
-Path to the `lucee-server` folder containing the `/context/lucee-server.xml` file. An example would be:
-
-```bash
-C:/lucee/tomcat/lucee-server/
-
-cfconfig export from=C:/lucee/tomcat/lucee-server/ to=myconfig.json
 ```
 
 ### Adobe 9/10/11/2016/2018/2021/2023/2025 CF Home


### PR DESCRIPTION
I also moved the lucee 4/5 web context example to be AFTER the lucee 4/5 server context example, since the latter is closer in folder structure to the new lucee 6/7 structure.

And I forgot to mention this in the commit, but note that I also found I had to add the fromFormat for my Lucee 6 example to work. This was for a standard Lucee install (not a commandbox embedded server). I appreciate that the rest of the page has discussions and examples of how the fromFormat is normally not needed. I didn't add text (in the doc) to EXPLAIN why I added that, but unless you might test and find that it can work WITHOUT it, it seems we should just leave it for those who WOULD need it.